### PR TITLE
Add websocket error handlers

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -48,6 +48,9 @@ if(exchanges.binance) {
     else if(obj.e == "depthUpdate")
       wall.binance(obj);
   });
+  sockets.binance.on('error', (err) => {
+    console.log('binance', err.code, '-', JSON.stringify(err.message));
+  });
 }
 
 if(exchanges.bitfinex) {
@@ -91,6 +94,9 @@ if(exchanges.bitfinex) {
       wall.bitfinex(obj);
     }
   });
+  sockets.bitfinex.on('error', (err) => {
+    console.log('bitfinex', err.code, '-', JSON.stringify(err.message));
+  });
 
 }
 
@@ -118,6 +124,9 @@ if(exchanges.coinbase) {
     // else if(obj.type == "l2update")
       // wall.coinbase(obj);
   })
+  sockets.coinbase.on('error', (err) => {
+    console.log('coinbase', err.code, '-', JSON.stringify(err.message));
+  });
 }
 
 


### PR DESCRIPTION
## Summary
- prevent crashes from websocket errors

## Testing
- `npm audit --production`
- `npm start` *(fails: Could not connect to database)*
- `npm test` *(fails: Could not connect to database)*

------
https://chatgpt.com/codex/tasks/task_e_685b0cbf2b9883299ea7874627d1a3fd