### PR TITLE
Add GDAX reconnect logic

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -48,6 +48,9 @@ if(exchanges.binance) {
     else if(obj.e == "depthUpdate")
       wall.binance(obj);
   });
+  sockets.binance.on('error', (err) => {
+    console.log('binance', err.code, '-', JSON.stringify(err.message));
+  });
 }
 
 if(exchanges.bitfinex) {
@@ -91,33 +94,49 @@ if(exchanges.bitfinex) {
       wall.bitfinex(obj);
     }
   });
+  sockets.bitfinex.on('error', (err) => {
+    console.log('bitfinex', err.code, '-', JSON.stringify(err.message));
+  });
 
 }
 
 if(exchanges.coinbase) {
-  sockets.coinbase = new WebSocket('wss://ws-feed.pro.coinbase.com')
+  const connectGdax = () => {
+    sockets.gdax = new WebSocket('wss://ws-feed.exchange.coinbase.com');
 
-  sockets.coinbase.on('open', () => {
- 
-    let request_object = {     
-      "type": "subscribe",     
-      "product_ids": getPairs("coinbase"),     
-      "channels": ["matches"] 
-    }
-  
-    sockets.coinbase.send(JSON.stringify(request_object))
-  
-    request_object.channels = ["level2"];
-    sockets.coinbase.send(JSON.stringify(request_object))
-  });
-  
-  sockets.coinbase.on('message', (data) => {
-    let obj = JSON.parse(data);
-    if(obj.type == "last_match" || obj.type == "match")
-      trade.coinbase(obj);
-    // else if(obj.type == "l2update")
-      // wall.coinbase(obj);
-  })
+    sockets.gdax.on('open', () => {
+
+      let request_object = {
+        "type": "subscribe",
+        "product_ids": getPairs("gdax"),
+        "channels": ["matches"]
+      };
+
+      sockets.gdax.send(JSON.stringify(request_object));
+
+      request_object.channels = ["level2"];
+      sockets.gdax.send(JSON.stringify(request_object));
+    });
+
+    sockets.gdax.on('message', (data) => {
+      let obj = JSON.parse(data);
+      if(obj.type == "last_match" || obj.type == "match")
+        trade.gdax(obj);
+      // else if(obj.type == "l2update")
+        // wall.gdax(obj);
+    });
+
+    sockets.gdax.on('error', (err) => {
+      console.log('gdax', err.code, '-', JSON.stringify(err.message));
+    });
+
+    sockets.gdax.on('close', () => {
+      console.log('gdax connection closed, retrying in 10s');
+      setTimeout(connectGdax, 10000);
+    });
+  };
+
+  connectGdax();
 }
 
 

--- a/lib/trades/coibase.js
+++ b/lib/trades/coibase.js
@@ -55,7 +55,7 @@ const coinbase = (trade) => {
     (usdExp.test(base)?1:usd_values[base]);
     
   if(trade_worth > min_worth[currency]) {
-    let volume = volumes.coinbase[symbol];
+    let volume = volumes.gdax[symbol] || 0;
     let messageObj = {
       event: "TRADE",
       symbol,

--- a/lib/trades/index.js
+++ b/lib/trades/index.js
@@ -7,5 +7,6 @@
 module.exports = {
   binance: require('./binance').binance,
   bitfinex: require('./bitfinex').bitfinex,
-  gdax: require('./coibase').coinbase
+  gdax: require('./coibase').coinbase,
+  coinbase: require('./coibase').coinbase
 }

--- a/lib/volume.js
+++ b/lib/volume.js
@@ -5,7 +5,8 @@ const {getPairs} = require('./pairs');
 let exchange_volumes = {
   binance: {},
   bitfinex: {},
-  gdax: {}
+  gdax: {},
+  coinbase: {}
 };
 
 let tickerOptions = {
@@ -38,10 +39,12 @@ const refresh_volumes = () => {
   });
   
   getPairs("gdax").forEach((symbol) => {
-    tickerOptions.uri = `https://api.gdax.com/products/${symbol}/ticker`;  
+    tickerOptions.uri = `https://api.gdax.com/products/${symbol}/ticker`;
     request(tickerOptions)
     .then(function (tickerResponse) {
-      exchange_volumes.gdax[symbol] = parseFloat(tickerResponse.volume);
+      const volume = parseFloat(tickerResponse.volume);
+      exchange_volumes.gdax[symbol] = volume;
+      exchange_volumes.coinbase[symbol] = volume;
     }).catch(function (err) {
       console.log("gdax", err.message);
     });


### PR DESCRIPTION
## Summary
- handle Coinbase (GDAX) connection drops by reconnecting
- ensure `getPairs('gdax')` is used and exported as `coinbase`
- keep volume tracking consistent for Coinbase

## Testing
- `npm audit --production`
- `npm start` *(fails: Cannot find module 'dotenv')*
- `npm test` *(fails: Cannot find module 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_685b0cbf2b9883299ea7874627d1a3fd