### PR TITLE
Fix Bitfinex volume error

### DIFF
--- a/lib/volume.js
+++ b/lib/volume.js
@@ -33,11 +33,15 @@ const refresh_volumes = () => {
   });
   
   getPairs().forEach((symbol) => {
-    tickerOptions.uri = `https://api.bitfinex.com/v2/candles/trade:1D:t${symbol}/last`; 
+    tickerOptions.uri = `https://api.bitfinex.com/v2/candles/trade:1D:t${symbol}/last`;
     request(tickerOptions)
     .then(function (tickerResponse) {
-      exchange_volumes.bitfinex[symbol] = tickerResponse[5];
-      console.log(`📊 Bitfinex ${symbol}: ${exchange_volumes.bitfinex[symbol]}`);
+      if (Array.isArray(tickerResponse) && tickerResponse.length >= 6 && tickerResponse[5] != null) {
+        exchange_volumes.bitfinex[symbol] = parseFloat(tickerResponse[5]);
+        console.log(`📊 Bitfinex ${symbol}: ${exchange_volumes.bitfinex[symbol]}`);
+      } else {
+        console.log('bitfinex: Unexpected ticker response for', symbol, '-', JSON.stringify(tickerResponse).substring(0, 100));
+      }
     }).catch(function (err) {
       console.log("bitfinex:", err.message);
     });


### PR DESCRIPTION
## Summary
- add validation when parsing Bitfinex candle data

## Testing
- `npm test` *(fails: Could not connect to database)*

------
https://chatgpt.com/codex/tasks/task_e_685bac5eed148329a59983efa09b025c