### PR TITLE
Fix Bitfinex pair format

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -57,7 +57,7 @@ if(exchanges.bitfinex) {
   sockets.bitfinex = new WebSocket('wss://api.bitfinex.com/ws/2'),
 
   sockets.bitfinex.on('open', () => {
-    const symbols = getPairs();
+    const symbols = getPairs('bitfinex');
   
     let request_object = { 
       event: "subscribe", 
@@ -66,7 +66,7 @@ if(exchanges.bitfinex) {
     }
   
     symbols.forEach(symbol => {
-      request_object.symbol = symbol;
+      request_object.symbol = `t${symbol}`;
       sockets.bitfinex.send(JSON.stringify(request_object))
     });
   
@@ -80,7 +80,7 @@ if(exchanges.bitfinex) {
     }
   
     symbols.forEach(symbol => {
-      request_object.symbol = symbol;
+      request_object.symbol = `t${symbol}`;
       sockets.bitfinex.send(JSON.stringify(request_object))
     });
   

--- a/lib/pairs.js
+++ b/lib/pairs.js
@@ -79,8 +79,16 @@ const getPairs = (exchange) => {
     });
   }
   else if(exchange.toLowerCase() === "bitfinex") {
-    // Bitfinex uses simple format without separators
-    pairs = default_pairs.slice(); // Copy array
+    // Bitfinex uses "UST" for Tether pairs and no separators
+    default_pairs.forEach((pair) => {
+      if(pair.includes("USDT")) {
+        let currency = pair.replace("USDT", "");
+        pairs.push(currency + "UST");
+      } else if(pair.includes("BTC")) {
+        let currency = pair.replace("BTC", "");
+        pairs.push(currency + "BTC");
+      }
+    });
   }
   
   return pairs;

--- a/lib/volume.js
+++ b/lib/volume.js
@@ -32,7 +32,7 @@ const refresh_volumes = () => {
     });
   });
   
-  getPairs().forEach((symbol) => {
+  getPairs('bitfinex').forEach((symbol) => {
     tickerOptions.uri = `https://api.bitfinex.com/v2/candles/trade:1D:t${symbol}/last`;
     request(tickerOptions)
     .then(function (tickerResponse) {


### PR DESCRIPTION
## Summary
- convert USDT pairs to UST for Bitfinex in `getPairs`
- subscribe with proper `t` prefix for Bitfinex websocket
- request Bitfinex volumes using Bitfinex formatted pairs

## Testing
- `npm test` *(fails: Could not connect to database)*

------
https://chatgpt.com/codex/tasks/task_e_685baf1ebcdc8329919d1b5eeb17060a