### PR TITLE
Fix order handling crash and add Bitfinex logging

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -57,6 +57,7 @@ if(exchanges.bitfinex) {
   sockets.bitfinex = new WebSocket('wss://api.bitfinex.com/ws/2'),
 
   sockets.bitfinex.on('open', () => {
+    console.log('Bitfinex WebSocket connected');
     const symbols = getPairs('bitfinex');
   
     let request_object = { 
@@ -65,9 +66,10 @@ if(exchanges.bitfinex) {
       symbol: "" 
     }
   
+    console.log('Bitfinex subscribing to trades for:', symbols);
     symbols.forEach(symbol => {
       request_object.symbol = `t${symbol}`;
-      sockets.bitfinex.send(JSON.stringify(request_object))
+      sockets.bitfinex.send(JSON.stringify(request_object));
     });
   
     request_object = { 
@@ -79,9 +81,10 @@ if(exchanges.bitfinex) {
       length: "25"  
     }
   
+    console.log('Bitfinex subscribing to order book for:', symbols);
     symbols.forEach(symbol => {
       request_object.symbol = `t${symbol}`;
-      sockets.bitfinex.send(JSON.stringify(request_object))
+      sockets.bitfinex.send(JSON.stringify(request_object));
     });
   
   });

--- a/lib/orders/binance.js
+++ b/lib/orders/binance.js
@@ -111,12 +111,15 @@ const binance = (order) => {
       && (first_run[symbol] || U == book[symbol].lastUId + 1)) {
     first_run[symbol] = false;
     try {
-      if(book[symbol].bids.length > 5)
+      if(book[symbol].bids.length > 5) {
         outlier = parseFloat(book[symbol].bids[book[symbol].bids.length-1][0]) - (23*sd(book[symbol].bids));
-      else
-        throw new Error("");
+      } else if(book[symbol].asks.length > 0) {
+        outlier = parseFloat(book[symbol].asks[0][0]) - (23*sd(book[symbol].asks));
+      } else {
+        throw new Error('empty order book');
+      }
     } catch(e) {
-      outlier = parseFloat(book[symbol].asks[0][0]) - (23*sd(book[symbol].asks));;
+      outlier = 0;
     }
     // console.log("bids", symbol, outlier)
     // console.log(book[symbol]);
@@ -149,13 +152,16 @@ const binance = (order) => {
     });
     
     try{
-      if(book[symbol].asks.length > 5)
+      if(book[symbol].asks.length > 5) {
         outlier = parseFloat(book[symbol].asks[0][0]) + (23*sd(book[symbol].asks));
-      else
-        throw new Error("");
+      } else if(book[symbol].bids.length > 0) {
+        outlier = parseFloat(book[symbol].bids[book[symbol].bids.length-1][0]) + (24*sd(book[symbol].bids));
+      } else {
+        throw new Error('empty order book');
+      }
     } catch(e) {
       // console.log(book[symbol]);
-      outlier = parseFloat(book[symbol].bids[book[symbol].bids.length-1][0]) + (24*sd(book[symbol].bids));
+      outlier = 0;
     }
     // console.log("asks", symbol, outlier)
     // console.log(book[symbol]);
@@ -193,9 +199,15 @@ const binance = (order) => {
     let askPrice = 0;
     
     try {
-      askPrice = parseFloat(book[symbol].asks[0][0]);
+      if(book[symbol].asks.length > 0) {
+        askPrice = parseFloat(book[symbol].asks[0][0]);
+      } else if(book[symbol].bids.length > 0) {
+        askPrice = parseFloat(book[symbol].bids[book[symbol].bids.length-1][0]);
+      } else {
+        throw new Error('empty order book');
+      }
     } catch(e) {
-      askPrice = parseFloat(book[symbol].bids[book[symbol].bids.length-1][0]);
+      askPrice = 0;
     }
 
     let usdExp = /^USD(T)?$/;


### PR DESCRIPTION
## Summary
- handle empty Binance order book entries gracefully
- add logs on Bitfinex websocket connection to confirm subscriptions

## Testing
- `npm test` *(fails: Could not connect to database)*

------
https://chatgpt.com/codex/tasks/task_e_685bb2749f1c8329934048d050b274d8