### PR TITLE
Fix currency parsing for USDT pairs

### DIFF
--- a/lib/pairs.js
+++ b/lib/pairs.js
@@ -10,8 +10,9 @@ const refreshUsdValues = () => {
   let request_string = "";
   
   default_pairs.forEach((pair, index) => {
-    let base = pair.substr(-3).toUpperCase();
-    if(base != "SDT" && base != "BTC" && base_currencies.indexOf(base) == -1) {
+    let base = pair.toUpperCase().endsWith('USDT') ? 'USDT' :
+      (pair.toUpperCase().endsWith('BTC') ? 'BTC' : pair.substr(-3).toUpperCase());
+    if(base !== 'USDT' && base !== 'BTC' && base_currencies.indexOf(base) === -1) {
       request_string += `t${base}USD,`;
       base_currencies.push(base);
     }
@@ -94,16 +95,18 @@ const getPairs = (exchange) => {
   return pairs;
 }
   
-  const getCurrencies = () => {
+const getCurrencies = () => {
   let trading_currencies = [];
-  
+
   default_pairs.forEach((pair) => {
-    let base = pair.substr(-3); // Base Exchange currency
-    let currency = pair.replace(base, ""); // Actual Traded Currency
-    if(trading_currencies.indexOf(currency) == -1) {
+    let base = pair.toUpperCase().endsWith('USDT') ? 'USDT' :
+      (pair.toUpperCase().endsWith('BTC') ? 'BTC' : pair.substr(-3));
+    let currency = pair.slice(0, -base.length);
+    if(trading_currencies.indexOf(currency) === -1) {
       trading_currencies.push(currency);
     }
   });
+
   return trading_currencies.sort();
 }
 


### PR DESCRIPTION
## Summary
- correctly identify base currency for USDT pairs when refreshing USD values
- fix `getCurrencies()` to strip full base suffixes

## Testing
- `npm test` *(fails: Could not connect to database)*

------
https://chatgpt.com/codex/tasks/task_e_685bbc36f5488329bbaf8ece3f2bd3b9