### PR TITLE
Fix currency parsing for USDT pairs

### DIFF
--- a/lib/message.js
+++ b/lib/message.js
@@ -75,8 +75,8 @@ const sendMessage = (chatOptions) => {
 const build = (messageObj) => {
   let event = messageObj.event;
   let symbol = messageObj.symbol;
-  let quantity = messageObj.quantity;
-  let price = messageObj.price;
+  let quantity = typeof messageObj.quantity !== 'undefined' ? parseFloat(messageObj.quantity) : undefined;
+  let price = typeof messageObj.price !== 'undefined' ? parseFloat(messageObj.price) : undefined;
   let exchange = messageObj.exchange;
   let to_id = undefined;
   let mo_id = undefined;
@@ -87,6 +87,9 @@ const build = (messageObj) => {
   let special_msg = "";
   let base = "";
   let currency = "";
+  const formatNumber = (num, decimals = 8) => {
+    return parseFloat(num).toFixed(decimals).replace(/\.0+$|(?<=\.[0-9]*?)0+$/g, '').replace(/\.$/, '');
+  };
   if(symbol) {
     let unformatted = symbol.replace("-","");
     base = unformatted.substr((symbol.substr(-4) == "USDT"?-4:-3));
@@ -112,20 +115,20 @@ const build = (messageObj) => {
   }
   
   if(event == "VOLUME") {
-    let type = messageObj.type;    
+    let type = messageObj.type;
     let side = messageObj.side;
     let size = Math.round(messageObj.size);
     if(typeof type == "object") {
-      special_msg = `( order of ${type[1]} ${currency} placed at ${type[0]} ${base})\n`;
-    } 
-    encoded_message = encodeURIComponent(`*VOLUME:*\n${symbol} (${exchange})\n${special_msg}Total ${side} volume = ${quantity} ${currency}, which is around ${size} times bigger than counterpart`);
+      special_msg = `( order of ${formatNumber(type[1])} ${currency} placed at ${formatNumber(type[0], 2)} ${base})\n`;
+    }
+    encoded_message = encodeURIComponent(`*VOLUME:*\n${symbol} (${exchange})\n${special_msg}Total ${formatNumber(quantity)} ${currency}, which is around ${size} times bigger than counterpart`);
 
   }
   else if(event == "TRADE") {
     if(quantity < 0)
-      encoded_message = encodeURIComponent(`*TRADE:*\n${symbol} (${exchange})\nSold ${quantity*-1} at ${price} ${base}${special_msg}`);
+      encoded_message = encodeURIComponent(`*TRADE:*\n${symbol} (${exchange})\nSold ${formatNumber(quantity*-1)} at ${formatNumber(price, 2)} ${base}${special_msg}`);
     else
-      encoded_message = encodeURIComponent(`*TRADE:*\n${symbol} (${exchange})\nBought ${quantity} at ${price} ${base}${special_msg}`);
+      encoded_message = encodeURIComponent(`*TRADE:*\n${symbol} (${exchange})\nBought ${formatNumber(quantity)} at ${formatNumber(price, 2)} ${base}${special_msg}`);
   }
   else if(event == "limit-change") {
     encoded_message = encodeURIComponent('*Limit change requested.*');

--- a/lib/pairs.js
+++ b/lib/pairs.js
@@ -10,8 +10,9 @@ const refreshUsdValues = () => {
   let request_string = "";
   
   default_pairs.forEach((pair, index) => {
-    let base = pair.substr(-3).toUpperCase();
-    if(base != "SDT" && base != "BTC" && base_currencies.indexOf(base) == -1) {
+    let base = pair.toUpperCase().endsWith('USDT') ? 'USDT' :
+      (pair.toUpperCase().endsWith('BTC') ? 'BTC' : pair.substr(-3).toUpperCase());
+    if(base !== 'USDT' && base !== 'BTC' && base_currencies.indexOf(base) === -1) {
       request_string += `t${base}USD,`;
       base_currencies.push(base);
     }
@@ -94,16 +95,18 @@ const getPairs = (exchange) => {
   return pairs;
 }
   
-  const getCurrencies = () => {
+const getCurrencies = () => {
   let trading_currencies = [];
-  
+
   default_pairs.forEach((pair) => {
-    let base = pair.substr(-3); // Base Exchange currency
-    let currency = pair.replace(base, ""); // Actual Traded Currency
-    if(trading_currencies.indexOf(currency) == -1) {
+    let base = pair.toUpperCase().endsWith('USDT') ? 'USDT' :
+      (pair.toUpperCase().endsWith('BTC') ? 'BTC' : pair.substr(-3));
+    let currency = pair.slice(0, -base.length);
+    if(trading_currencies.indexOf(currency) === -1) {
       trading_currencies.push(currency);
     }
   });
+
   return trading_currencies.sort();
 }
 


### PR DESCRIPTION
## Summary
- correctly identify base currency for USDT pairs when refreshing USD values
- fix `getCurrencies()` to strip full base suffixes
- refine alert message formatting with a helper to remove trailing zeros

## Testing
- `npm install` *(fails: command failed due to database connection)*
- `npm test` *(fails: Could not connect to database)*

------
https://chatgpt.com/codex/tasks/task_e_685bbc36f5488329bbaf8ece3f2bd3b9